### PR TITLE
added webserver and updated i2s to actually compile

### DIFF
--- a/Mncast/Homeassistant/mn-cast.yaml
+++ b/Mncast/Homeassistant/mn-cast.yaml
@@ -26,19 +26,24 @@ wifi:
     ssid: "password_is_musemuse"
     password: "musemuse"
 
+web_server:
+  port: 80
+
 media_player:
   - platform: i2s_audio
     id: media_out
     name: MnCast
     dac_type: external
-    i2s_lrclk_pin: GPIO25
     i2s_dout_pin: GPIO26
-    i2s_bclk_pin: GPIO5
     mode: stereo
     mute_pin:
       number: GPIO33
       inverted: true
 
+i2s_audio:
+  i2s_lrclk_pin: GPIO25
+  i2s_bclk_pin: GPIO5
+  
 binary_sensor:
   - platform: gpio
     pin:


### PR DESCRIPTION
the webserver allows access to the unit without Home Assistant and to easily upload a different firmware. The i2s media player needed updating to allow compiling.